### PR TITLE
Improve typing on PersistConfig black/whitelist

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -31,8 +31,8 @@ declare module "reduxjs-toolkit-persist/es/types" {
      * @deprecated keyPrefix is going to be removed in v6.
      */
     keyPrefix?: string;
-    blacklist?: Array<string>;
-    whitelist?: Array<string>;
+    blacklist?: Array<string & keyof S>;
+    whitelist?: Array<string & keyof S>;
     transforms?: Array<Transform<HSS, ESS, S, RS>>;
     throttle?: number;
     migrate?: PersistMigrate;


### PR DESCRIPTION
I kept running into issues where I'd rename some state and the blacklist/whitelist would stop working. I fixed it in my code like this, thought I'd merge it into here as well.